### PR TITLE
[codex] improve evaluation docs and leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,12 +85,97 @@ experiments. It is not a clinical decision system.
 Use Python 3.10 or newer.
 
 ```bash
-pip install -r requirements.txt
-python run_llm/huggingface.py
-python evaluate_performance.py
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install -r requirements.txt
+python run_llm/huggingface.py --output results/example-pubmedqa.json
+python evaluate_performance.py --results results/example-pubmedqa.json
 ```
 
-Run commands from the repository root.
+Run commands from the repository root. The default Hugging Face run evaluates
+`birgermoell/eir` on PubMedQA-Swedish and writes a SMLB-compatible results JSON.
+
+## Evaluate a Model
+
+Use this workflow when you want to evaluate a new model, compare two models, or
+measure a change such as fine-tuning, RAG, quantization, prompting, or decoding
+settings. The most important rule is to keep the benchmark list, prompt
+templates, and decoding settings fixed across the runs you want to compare.
+
+Choose the benchmark list before looking at the results. If you can, run every
+benchmark supported by your runner. If you only run a subset because of cost,
+context length, licensing, hardware, or a specific research question, report the
+subset clearly and avoid presenting it as a full SMLB score.
+
+```bash
+python run_llm/huggingface.py \
+  --model-name /path/to/model-or-hf-id \
+  --benchmarks EmergencyMedicine GeneralPractioner SwedishDoctorsExam PubMedQA-L-SWE \
+  --output results/my-model-smlb.json
+```
+
+For a before/after comparison, run the same command twice and only change the
+model path or ID:
+
+```bash
+python run_llm/huggingface.py \
+  --model-name /path/to/baseline-model \
+  --benchmarks EmergencyMedicine GeneralPractioner SwedishDoctorsExam PubMedQA-L-SWE \
+  --output results/my-model-baseline-smlb.json
+
+python run_llm/huggingface.py \
+  --model-name /path/to/changed-model \
+  --benchmarks EmergencyMedicine GeneralPractioner SwedishDoctorsExam PubMedQA-L-SWE \
+  --output results/my-model-changed-smlb.json
+```
+
+Then evaluate each result file. Saving the text report is helpful when opening a
+PR, comparing runs, or writing a paper:
+
+```bash
+python evaluate_performance.py \
+  --results results/my-model-smlb.json \
+  --save-result-path results/my-model-smlb-eval.txt
+```
+
+Each results JSON stores `llm_info`, benchmark names, prompts, item IDs, ground
+truths, and predictions. Keep the JSON file with the text report so the run can
+be audited later.
+
+### Reporting New Results
+
+When reporting or submitting a new model result, include enough information for
+someone else to reproduce the evaluation:
+
+- exact model name, provider, checkpoint, revision, or local checkpoint
+  description,
+- whether the model is base, instruction-tuned, fine-tuned, RAG-assisted,
+  quantized, merged, distilled, or otherwise modified,
+- benchmark list, number of evaluated questions per benchmark, and any skipped
+  benchmarks,
+- prompt templates and answer-format instructions,
+- decoding settings such as sampling, temperature, top-p, max tokens, and seed
+  when applicable,
+- hardware/runtime details if they affect the result, such as quantization,
+  precision, or inference framework,
+- SMLB commit hash and the exact runner and evaluation commands,
+- result JSON file and evaluation text output,
+- malformed-answer counts as well as accuracy/F1,
+- a contamination statement: whether SMLB questions, answers, explanations, or
+  prompts were used for training, synthetic data generation, prompt tuning,
+  reward modeling, retrieval, model selection, or manual debugging.
+
+If you want a model added to the public results table, open an issue or pull
+request with the result JSON, the text evaluation report, and the metadata above.
+Partial results are welcome when they are clearly marked. Results with known
+SMLB contamination can still be useful for analysis, but they should not be
+described as external benchmark results.
+
+Accuracy is useful for the multiple-choice tasks, but avoid relying on a single
+aggregate score. PubMedQA-Swedish is label-imbalanced, so inspect precision,
+recall, F1, and the confusion matrix for `ja`, `nej`, and `kanske`. For model
+comparison studies, report the per-benchmark delta and watch for regressions on
+benchmarks outside the target domain or tuning objective.
 
 ## GRPO / RLVR Experiments
 
@@ -164,8 +249,9 @@ without rediscovering the basics.
 - Project goal: evaluate LLMs on Swedish medical benchmark tasks.
 - Default working directory: repository root.
 - Use Python 3.10+.
-- Main evaluation entry point: `python evaluate_performance.py`.
-- Hugging Face runner example: `python run_llm/huggingface.py`.
+- Main evaluation entry point: `python evaluate_performance.py --results results/example-pubmedqa.json`.
+- Hugging Face runner example: `python run_llm/huggingface.py --model-name /path/to/model --benchmarks PubMedQA-L-SWE --output results/example-pubmedqa.json`.
+- Supported Hugging Face benchmark names: `PubMedQA-L-SWE`, `GeneralPractioner`, `EmergencyMedicine`, `SwedishDoctorsExam`.
 - Benchmark implementations live in `run_llm/benchmark_set_up.py`.
 - Human-readable benchmark descriptions live in `benchmarks/BENCHMARK_DESCRIPTIONS.md`.
 - GRPO dataset builder: `python grpo/build_grpo_dataset.py --output-dir data/grpo`.

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="Swedish Medical Benchmark: a framework for evaluating large language models in the Swedish medical domain.">
+  <meta name="description" content="Swedish Medical Benchmark: external evaluation and leaderboard for Swedish medical LLMs.">
   <meta name="author" content="Swedish Medical Benchmark">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="Swedish Medical Benchmark">
   <meta property="og:title" content="Swedish Medical Benchmark (SMLB)">
-  <meta property="og:description" content="A framework for evaluating large language models in the Swedish medical domain.">
+  <meta property="og:description" content="External evaluation and leaderboard for Swedish medical LLMs.">
   <meta property="og:url" content="https://birgermoell.github.io/swedish-medical-benchmark/">
   <meta property="og:image" content="https://birgermoell.github.io/swedish-medical-benchmark/SMLB.png">
   <meta property="og:image:secure_url" content="https://birgermoell.github.io/swedish-medical-benchmark/SMLB.png">
@@ -18,7 +18,7 @@
   <meta property="og:image:alt" content="Overview diagram of the Swedish Medical Benchmark framework">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Swedish Medical Benchmark (SMLB)">
-  <meta name="twitter:description" content="A framework for evaluating large language models in the Swedish medical domain.">
+  <meta name="twitter:description" content="External evaluation and leaderboard for Swedish medical LLMs.">
   <meta name="twitter:image" content="https://birgermoell.github.io/swedish-medical-benchmark/SMLB.png">
   <meta name="twitter:image:alt" content="Overview diagram of the Swedish Medical Benchmark framework">
   <link rel="canonical" href="https://birgermoell.github.io/swedish-medical-benchmark/">
@@ -227,6 +227,49 @@
       gap: 16px;
     }
 
+    .workflow {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 18px;
+      margin: 26px 0 18px;
+      font-family: Arial, Helvetica, sans-serif;
+    }
+
+    .step {
+      border-top: 3px solid var(--blue);
+      padding-top: 14px;
+    }
+
+    .step strong {
+      display: block;
+      margin-bottom: 8px;
+      color: var(--ink);
+      font-size: 16px;
+    }
+
+    .step p {
+      margin: 0;
+      color: var(--muted);
+      font-size: 15px;
+    }
+
+    .command-block {
+      margin: 18px 0;
+      padding: 16px 18px;
+      overflow-x: auto;
+      border: 1px solid rgba(7, 27, 70, 0.28);
+      border-radius: 6px;
+      background: #17213b;
+      color: var(--white);
+      font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+      font-size: 14px;
+      line-height: 1.55;
+    }
+
+    .command-block code {
+      white-space: pre;
+    }
+
     .panel {
       border: 1px solid var(--line);
       border-radius: 6px;
@@ -332,6 +375,7 @@
 
       .metrics,
       .grid,
+      .workflow,
       .figure-grid {
         grid-template-columns: 1fr;
       }
@@ -348,7 +392,8 @@
       <a class="brand" href="#">Swedish Medical Benchmark</a>
       <div class="nav-links">
         <a href="#benchmarks">Benchmarks</a>
-        <a href="#results">Results</a>
+        <a href="#evaluate">Evaluate</a>
+        <a href="#leaderboard">Leaderboard</a>
         <a href="#figures">Figures</a>
         <a href="#grpo">GRPO</a>
         <a href="#contribute">Contribute</a>
@@ -364,6 +409,7 @@
       <p class="byline">Created by Birger Moëll, Fabian Farestam, and Jonas Beskow.</p>
       <div class="actions">
         <a class="button" href="https://github.com/BirgerMoell/swedish-medical-benchmark/">View on GitHub</a>
+        <a class="button secondary" href="#evaluate">Evaluate a model</a>
         <a class="button secondary" href="https://www.frontiersin.org/journals/artificial-intelligence/articles/10.3389/frai.2025.1557920/full">Read the paper</a>
       </div>
     </div>
@@ -379,7 +425,8 @@
         SMLB measures how language models handle Swedish medical terminology,
         clinical reasoning, exam-style questions, emergency scenarios, and
         general medicine cases. It is designed for transparent model comparison,
-        research, and medical education experiments.
+        before/after fine-tuning studies, research, and medical education
+        experiments.
       </p>
       <div class="metrics">
         <div class="metric"><strong>1,000</strong><span>PubMedQA-Swedish questions</span></div>
@@ -411,9 +458,53 @@
       </div>
     </section>
 
-    <section id="results" aria-labelledby="results-title">
-      <h2 id="results-title">Preliminary Model Results</h2>
-      <p class="section-intro">Accuracy is reported as a percentage. A dash means the model has not been evaluated on that benchmark in the current table.</p>
+    <section id="evaluate" aria-labelledby="evaluate-title">
+      <h2 id="evaluate-title">Evaluate a Model</h2>
+      <p class="section-intro">
+        Use SMLB to evaluate a new model, compare two models, or measure a
+        change such as fine-tuning, RAG, quantization, prompting, or decoding
+        settings. Keep the benchmark list, prompt templates, and decoding
+        settings fixed across runs you want to compare.
+      </p>
+      <div class="workflow">
+        <div class="step">
+          <strong>1. Choose fixed tasks</strong>
+          <p>Run every supported benchmark when possible. If you use a subset, report exactly which benchmarks and question counts were included.</p>
+        </div>
+        <div class="step">
+          <strong>2. Save the run</strong>
+          <p>Save the result JSON and evaluation text output. Keep prompts, answer formats, model metadata, and decoding settings with the result.</p>
+        </div>
+        <div class="step">
+          <strong>3. Report clearly</strong>
+          <p>Report per-benchmark metrics, malformed answers, and PubMedQA label behavior. For comparisons, include the per-benchmark delta.</p>
+        </div>
+      </div>
+      <pre class="command-block"><code>python run_llm/huggingface.py \
+  --model-name /path/to/model-or-hf-id \
+  --benchmarks EmergencyMedicine GeneralPractioner SwedishDoctorsExam PubMedQA-L-SWE \
+  --output results/my-model-smlb.json
+
+python evaluate_performance.py \
+  --results results/my-model-smlb.json \
+  --save-result-path results/my-model-smlb-eval.txt</code></pre>
+      <div class="callout">
+        Want to add a model to the leaderboard? Submit the result JSON,
+        evaluation text output, exact model/checkpoint, benchmark list, prompt,
+        decoding settings, SMLB commit, malformed-answer counts, and a
+        contamination statement. See the
+        <a href="https://github.com/BirgerMoell/swedish-medical-benchmark/#evaluate-a-model">full README workflow</a>.
+      </div>
+    </section>
+
+    <section id="leaderboard" aria-labelledby="leaderboard-title">
+      <h2 id="leaderboard-title">Preliminary Leaderboard</h2>
+      <p class="section-intro">
+        Accuracy is reported as a percentage. A dash means the model has not
+        been evaluated on that benchmark in the current table. Because some rows
+        are partial, compare models benchmark by benchmark rather than treating
+        this as a single overall ranking.
+      </p>
       <div class="table-wrap">
         <table>
           <thead>
@@ -431,9 +522,21 @@
             <tr><td>GPT-4</td><td>53.90</td><td>79.07</td><td><strong>93.10</strong></td><td><strong>93.09</strong></td><td><strong>75.57</strong></td></tr>
             <tr><td>Claude-3.5</td><td>-</td><td><strong>83.74</strong></td><td>-</td><td>-</td><td>-</td></tr>
             <tr><td>Llama3-70b</td><td>56.00</td><td>69.91</td><td>74.35</td><td>67.57</td><td>64.88</td></tr>
+            <tr><td>Llama3-8b</td><td>50.50</td><td>41.68</td><td>-</td><td>-</td><td>-</td></tr>
+            <tr><td>Llama3.1-70b</td><td>-</td><td>71.40</td><td>62.93</td><td>71.02</td><td>-</td></tr>
+            <tr><td>Llama3.1-8b</td><td>-</td><td>6.36</td><td>-</td><td>-</td><td>-</td></tr>
             <tr><td>Gemma2-9b</td><td>-</td><td>61.31</td><td>-</td><td>-</td><td>-</td></tr>
+            <tr><td>Gemma-7b</td><td>48.70</td><td>27.48</td><td>-</td><td>-</td><td>-</td></tr>
+            <tr><td>EIR</td><td>46.50</td><td>-</td><td>-</td><td>-</td><td>-</td></tr>
+            <tr><td>GPT-3.5</td><td>27.40</td><td>-</td><td>-</td><td>-</td><td>-</td></tr>
           </tbody>
         </table>
+      </div>
+      <div class="callout" style="margin-top: 18px;">
+        New leaderboard entries should include the result JSON, evaluation text
+        output, model metadata, benchmark coverage, decoding settings, and
+        contamination statement. Partial results are welcome when they are
+        clearly marked.
       </div>
     </section>
 

--- a/evaluate_performance.py
+++ b/evaluate_performance.py
@@ -1,7 +1,9 @@
 import json
+import argparse
 import numpy as np
 
 from functools import partial
+from pathlib import Path
 from sklearn.metrics import (
     accuracy_score,
     precision_score,
@@ -23,24 +25,74 @@ MIN_SAMPLES = 50  # Minimum number of samples to consider a group
 SAVE_RESULT_PATH = (
     None  # If saving to file set it to something like: "eval_results.txt"
 )
-OUTPUT_FILE = open(SAVE_RESULT_PATH, "w") if SAVE_RESULT_PATH else None
 AVERAGE_METHOD = None  # Can be "micro", "macro", "weighted", "samples", None
-
-printo = partial(print, file=OUTPUT_FILE)
 
 
 # Functions
 # =========
-def calculate_metrics(ground_truths: list[str], predictions: list[str]):
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Evaluate an SMLB results JSON file."
+    )
+    parser.add_argument(
+        "--results",
+        default=PATH,
+        help="Path to a results JSON file produced by a runner.",
+    )
+    parser.add_argument(
+        "--save-result-path",
+        default=SAVE_RESULT_PATH,
+        help="Optional text file where evaluation output should be written.",
+    )
+    parser.add_argument(
+        "--print-all",
+        action="store_true",
+        default=PRINT_ALL,
+        help="Print all property groups instead of only the top and bottom 5.",
+    )
+    parser.add_argument(
+        "--include-all-metrics-in-property",
+        action="store_true",
+        default=INCLUDE_ALL_METRICS_IN_PROPERTY,
+        help="Print all metrics for each property group.",
+    )
+    parser.add_argument(
+        "--rank-by",
+        choices=["accuracy", "precision", "recall", "f1"],
+        default=RANK_BY,
+        help="Metric used to rank property groups.",
+    )
+    parser.add_argument(
+        "--min-samples",
+        type=int,
+        default=MIN_SAMPLES,
+        help="Minimum samples required for property-level reporting.",
+    )
+    parser.add_argument(
+        "--average-method",
+        choices=["micro", "macro", "weighted", "samples"],
+        default=AVERAGE_METHOD,
+        help="Optional sklearn averaging method for precision, recall, and F1.",
+    )
+    return parser.parse_args()
+
+
+def calculate_metrics(
+    ground_truths: list[str],
+    predictions: list[str],
+    average_method: str | None = AVERAGE_METHOD,
+):
     metrics = {
         "accuracy": accuracy_score(ground_truths, predictions),
         "precision": precision_score(
-            ground_truths, predictions, average=AVERAGE_METHOD, zero_division=0
+            ground_truths, predictions, average=average_method, zero_division=0
         ),
         "recall": recall_score(
-            ground_truths, predictions, average=AVERAGE_METHOD, zero_division=0
+            ground_truths, predictions, average=average_method, zero_division=0
         ),
-        "f1": f1_score(ground_truths, predictions, average=AVERAGE_METHOD),
+        "f1": f1_score(
+            ground_truths, predictions, average=average_method, zero_division=0
+        ),
         "confusion_matrix": confusion_matrix(ground_truths, predictions),
     }
     return {
@@ -49,12 +101,12 @@ def calculate_metrics(ground_truths: list[str], predictions: list[str]):
     }
 
 
-def print_metrics(metrics: dict):
-    printo(f"Accuracy: {metrics['accuracy']}")
-    printo(f"Precision: {metrics['precision']}")
-    printo(f"Recall: {metrics['recall']}")
-    printo(f"F1: {metrics['f1']}")
-    printo(f"Confusion Matrix:\n{metrics['confusion_matrix']}")
+def print_metrics(metrics: dict, print_fn=print):
+    print_fn(f"Accuracy: {metrics['accuracy']}")
+    print_fn(f"Precision: {metrics['precision']}")
+    print_fn(f"Recall: {metrics['recall']}")
+    print_fn(f"F1: {metrics['f1']}")
+    print_fn(f"Confusion Matrix:\n{metrics['confusion_matrix']}")
 
 
 def get_groups_by_property(ids: list[str], property: str, benchmark: Benchmark):
@@ -68,14 +120,20 @@ def get_groups_by_property(ids: list[str], property: str, benchmark: Benchmark):
     return groups
 
 
-def evaluate_property(benchmark_results, property_groups):
+def evaluate_property(
+    benchmark_results,
+    property_groups,
+    average_method: str | None = AVERAGE_METHOD,
+    min_samples: int = MIN_SAMPLES,
+):
     property_results = {}
     for name, group in property_groups.items():
-        if len(group) < MIN_SAMPLES:
+        if len(group) < min_samples:
             continue
         metrics = calculate_metrics(
             [benchmark_results["ground_truths"][i] for i in group],
             [benchmark_results["predictions"][i] for i in group],
+            average_method,
         )
         property_results[name] = metrics
     return property_results
@@ -83,58 +141,81 @@ def evaluate_property(benchmark_results, property_groups):
 
 # Main
 # ====
-if __name__ == "__main__":
+def main():
+    args = parse_args()
+    output_file = None
+    if args.save_result_path:
+        save_path = Path(args.save_result_path)
+        save_path.parent.mkdir(parents=True, exist_ok=True)
+        output_file = save_path.open("w")
+    printo = partial(print, file=output_file) if output_file else print
+
     # Load the results
-    with open(PATH, "r") as f:
-        results = json.load(f)
-    for benchmark_name, benchmark_results in results.items():
-        if benchmark_name == "llm_info":
-            continue
-        printo(f"\n\nBenchmark: {benchmark_name}")
-        printo("=====================================")
-        benchmark = get_benchmark_by_name(benchmark_name)
+    try:
+        with open(args.results, "r") as f:
+            results = json.load(f)
+        for benchmark_name, benchmark_results in results.items():
+            if benchmark_name == "llm_info":
+                continue
+            printo(f"\n\nBenchmark: {benchmark_name}")
+            printo("=====================================")
+            benchmark = get_benchmark_by_name(benchmark_name)
 
-        # Evaluate the overall performance
-        metrics = calculate_metrics(
-            benchmark_results["ground_truths"], benchmark_results["predictions"]
-        )
-        printo("Overall performance:")
-        printo("--------------------")
-        print_metrics(metrics)
-        printo("--------------------\n")
+            # Evaluate the overall performance
+            metrics = calculate_metrics(
+                benchmark_results["ground_truths"],
+                benchmark_results["predictions"],
+                args.average_method,
+            )
+            printo("Overall performance:")
+            printo("--------------------")
+            print_metrics(metrics, printo)
+            printo("--------------------\n")
 
-        # Evaluate the performance by property
-        printo("Performance by property:")
-        printo("--------------------")
-        for property_name in benchmark.label_tag_groups:
-            property_groups = get_groups_by_property(
-                benchmark_results["ids"], property_name, benchmark
-            )
-            property_results = evaluate_property(benchmark_results, property_groups)
-            printo(f"{property_name.capitalize()} performance ranking:")
-            printo("------------------------------------")
-            sorted_results = sorted(
-                property_results.items(),
-                key=lambda x: (
-                    x[1][RANK_BY] if AVERAGE_METHOD else np.mean(x[1][RANK_BY])
-                ),
-                reverse=True,
-            )
-            for name, metrics in sorted_results[: 5 if not PRINT_ALL else None]:
-                printo(
-                    f"{name} ({RANK_BY}; n={len(property_groups[name])}): {metrics[RANK_BY]}"
+            # Evaluate the performance by property
+            printo("Performance by property:")
+            printo("--------------------")
+            for property_name in benchmark.label_tag_groups:
+                property_groups = get_groups_by_property(
+                    benchmark_results["ids"], property_name, benchmark
                 )
-                if INCLUDE_ALL_METRICS_IN_PROPERTY:
-                    print_metrics(metrics)
-            if not PRINT_ALL:
-                printo("...")
-                printo("- 5 Worst performing groups:")
-                for name, metrics in sorted_results[-5:][::-1]:
+                property_results = evaluate_property(
+                    benchmark_results,
+                    property_groups,
+                    args.average_method,
+                    args.min_samples,
+                )
+                printo(f"{property_name.capitalize()} performance ranking:")
+                printo("------------------------------------")
+                sorted_results = sorted(
+                    property_results.items(),
+                    key=lambda x: (
+                        x[1][args.rank_by]
+                        if args.average_method
+                        else np.mean(x[1][args.rank_by])
+                    ),
+                    reverse=True,
+                )
+                for name, metrics in sorted_results[: 5 if not args.print_all else None]:
                     printo(
-                        f"{name} ({RANK_BY}; n={len(property_groups[name])}): {metrics[RANK_BY]}"
+                        f"{name} ({args.rank_by}; n={len(property_groups[name])}): {metrics[args.rank_by]}"
                     )
-                    if INCLUDE_ALL_METRICS_IN_PROPERTY:
-                        print_metrics(metrics)
-            printo("------------------------------------")
-    if OUTPUT_FILE:
-        OUTPUT_FILE.close()
+                    if args.include_all_metrics_in_property:
+                        print_metrics(metrics, printo)
+                if not args.print_all:
+                    printo("...")
+                    printo("- 5 Worst performing groups:")
+                    for name, metrics in sorted_results[-5:][::-1]:
+                        printo(
+                            f"{name} ({args.rank_by}; n={len(property_groups[name])}): {metrics[args.rank_by]}"
+                        )
+                        if args.include_all_metrics_in_property:
+                            print_metrics(metrics, printo)
+                printo("------------------------------------")
+    finally:
+        if output_file:
+            output_file.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/run_llm/huggingface.py
+++ b/run_llm/huggingface.py
@@ -1,9 +1,11 @@
 import json
+import argparse
 import numpy as np
 import torch
 import transformers
 import benchmark_set_up as benchmarks
 import datetime
+from pathlib import Path
 
 from functools import lru_cache
 from tqdm import tqdm
@@ -15,19 +17,43 @@ MODEL_NAME = "birgermoell/eir"
 PubMedQALSWE_SYSTEM_PROMPT = "Var vänlig och överväg varje aspekt av medicinska frågan nedan noggrant. Ta en stund, andas djupt, och när du känner dig redo, vänligen svara med endast ett av de fördefinierade svaren: 'ja', 'nej', eller 'kanske'. Det är viktigt att du begränsar ditt svar till dessa alternativ för att säkerställa tydlighet i kommunikationen."
 GeneralPractioner_SYSTEM_PROMPT = "Du är en utmärkt läkare och skriver ett läkarprov. Var vänlig och överväg varje aspekt av medicinska frågan nedan noggrant. Ta en stund, andas djupt, och när du känner dig redo, vänligen svara med endast ett av alternativen."
 SwedishDoctorsExam = "Du är en utmärkt läkare och skriver ett läkarprov. Var vänlig och överväg varje aspekt av medicinska frågan nedan noggrant. Ta en stund, andas djupt, och när du känner dig redo, vänligen svara med endast ett av alternativen. Svara med hela svarsalternativet. Utöver det är det viktigt att du inte inkluderar någon annan text i ditt svar."
-# Make sure to uncomment the benchmarks you want to run
-BENCHMARKS = [
-    benchmarks.PubMedQALSWE(
+
+
+def pubmedqa_swe():
+    return benchmarks.PubMedQALSWE(
         prompt=PubMedQALSWE_SYSTEM_PROMPT
         + "\n\nFråga:\n{question} svara bara 'ja', 'nej' eller 'kanske'"
-    ),
-    # Uncomment to also run the GeneralPractioner benchmark
-    # benchmarks.GeneralPractioner(
-    #     prompt=GeneralPractioner_SYSTEM_PROMPT
-    #     + "\n\nFråga:\n{question}\nAlternativ:{options}\n\nSvara endast ett av alternativen."
-    # ),
-    # benchmarks.SwedishDoctorsExam(prompt=SwedishDoctorsExam + "\n\nFråga:\n{question}\n\nSvara med endast ett av alternativen. Svara med hela svarsalternativet."),
-]
+    )
+
+
+def general_practitioner():
+    return benchmarks.GeneralPractioner(
+        prompt=GeneralPractioner_SYSTEM_PROMPT
+        + "\n\nFråga:\n{question}\n\nSvara med endast ett av alternativen. Svara med hela svarsalternativet."
+    )
+
+
+def emergency_medicine():
+    return benchmarks.EmergencyMedicine(
+        prompt=GeneralPractioner_SYSTEM_PROMPT
+        + "\n\nFråga:\n{question}\n\nSvara med endast ett av alternativen. Svara med hela svarsalternativet."
+    )
+
+
+def swedish_doctors_exam():
+    return benchmarks.SwedishDoctorsExam(
+        prompt=SwedishDoctorsExam
+        + "\n\nFråga:\n{question}\n\nSvara med endast ett av alternativen. Svara med hela svarsalternativet."
+    )
+
+
+BENCHMARK_FACTORIES = {
+    "PubMedQA-L-SWE": pubmedqa_swe,
+    "GeneralPractioner": general_practitioner,
+    "EmergencyMedicine": emergency_medicine,
+    "SwedishDoctorsExam": swedish_doctors_exam,
+}
+DEFAULT_BENCHMARKS = ["PubMedQA-L-SWE"]
 PIPELINE_PARAMS = {"do_sample": False}
 
 
@@ -56,26 +82,55 @@ def timestamp():
     return datetime.datetime.now().isoformat()
 
 
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Run one or more SMLB benchmarks with a local Hugging Face model."
+    )
+    parser.add_argument(
+        "--model-name",
+        default=MODEL_NAME,
+        help="Hugging Face model id or local checkpoint path.",
+    )
+    parser.add_argument(
+        "--benchmarks",
+        nargs="+",
+        choices=sorted(BENCHMARK_FACTORIES),
+        default=DEFAULT_BENCHMARKS,
+        help="Benchmarks to run. Keep this list fixed for before/after comparisons.",
+    )
+    parser.add_argument(
+        "--output",
+        default="results.json",
+        help="Where to save predictions and metadata.",
+    )
+    return parser.parse_args()
+
+
 # Main
 # ====
 if __name__ == "__main__":
-    pipeline = load_pipeline()
+    args = parse_args()
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    pipeline = load_pipeline(args.model_name)
+    benchmarks_to_run = [BENCHMARK_FACTORIES[name]() for name in args.benchmarks]
     result = {
         "llm_info": {
-            "model": MODEL_NAME,
+            "model": args.model_name,
+            "benchmarks": args.benchmarks,
             "pipeline_params": PIPELINE_PARAMS,
             "model_run": timestamp(),
+            "runner": "run_llm/huggingface.py",
         },
     }
-    for benchmark in BENCHMARKS:
+    for benchmark in benchmarks_to_run:
         llm_results = []
         ids = []
         ground_truths = benchmark.get_ground_truth()
 
         for k, v in tqdm(benchmark.data.items(), desc=f"Processing {benchmark.name}"):
-            messages = [
-                fmt_message("user", benchmark.prompt.format(question=v["QUESTION"]))
-            ]
+            messages = [fmt_message("user", benchmark.final_prompt_format(v))]
             out = pipeline(
                 messages,
                 max_new_tokens=benchmark.max_tokens,
@@ -90,8 +145,8 @@ if __name__ == "__main__":
                 "predictions": predictions.tolist(),
                 "ids": ids,
             }
-            with open("./results.json", "w") as f:
-                json.dump(result, f)
+            with output_path.open("w") as f:
+                json.dump(result, f, ensure_ascii=False, indent=2)
 
         assert len(ground_truths) == len(predictions)
 
@@ -99,5 +154,5 @@ if __name__ == "__main__":
         print(f"Malformed answers {(predictions == 'missformat').sum()}")
 
     print(
-        "Done! You can now run the evaluate_results.py script to get detailed performance metrics."
+        f"Done! Results saved to {output_path}. You can now run evaluate_performance.py for detailed metrics."
     )

--- a/website/index.html
+++ b/website/index.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="Swedish Medical Benchmark: a framework for evaluating large language models in the Swedish medical domain.">
+  <meta name="description" content="Swedish Medical Benchmark: external evaluation and leaderboard for Swedish medical LLMs.">
   <meta name="author" content="Swedish Medical Benchmark">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="Swedish Medical Benchmark">
   <meta property="og:title" content="Swedish Medical Benchmark (SMLB)">
-  <meta property="og:description" content="A framework for evaluating large language models in the Swedish medical domain.">
+  <meta property="og:description" content="External evaluation and leaderboard for Swedish medical LLMs.">
   <meta property="og:url" content="https://birgermoell.github.io/swedish-medical-benchmark/">
   <meta property="og:image" content="https://birgermoell.github.io/swedish-medical-benchmark/SMLB.png">
   <meta property="og:image:secure_url" content="https://birgermoell.github.io/swedish-medical-benchmark/SMLB.png">
@@ -18,7 +18,7 @@
   <meta property="og:image:alt" content="Overview diagram of the Swedish Medical Benchmark framework">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Swedish Medical Benchmark (SMLB)">
-  <meta name="twitter:description" content="A framework for evaluating large language models in the Swedish medical domain.">
+  <meta name="twitter:description" content="External evaluation and leaderboard for Swedish medical LLMs.">
   <meta name="twitter:image" content="https://birgermoell.github.io/swedish-medical-benchmark/SMLB.png">
   <meta name="twitter:image:alt" content="Overview diagram of the Swedish Medical Benchmark framework">
   <link rel="canonical" href="https://birgermoell.github.io/swedish-medical-benchmark/">
@@ -227,6 +227,49 @@
       gap: 16px;
     }
 
+    .workflow {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 18px;
+      margin: 26px 0 18px;
+      font-family: Arial, Helvetica, sans-serif;
+    }
+
+    .step {
+      border-top: 3px solid var(--blue);
+      padding-top: 14px;
+    }
+
+    .step strong {
+      display: block;
+      margin-bottom: 8px;
+      color: var(--ink);
+      font-size: 16px;
+    }
+
+    .step p {
+      margin: 0;
+      color: var(--muted);
+      font-size: 15px;
+    }
+
+    .command-block {
+      margin: 18px 0;
+      padding: 16px 18px;
+      overflow-x: auto;
+      border: 1px solid rgba(7, 27, 70, 0.28);
+      border-radius: 6px;
+      background: #17213b;
+      color: var(--white);
+      font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+      font-size: 14px;
+      line-height: 1.55;
+    }
+
+    .command-block code {
+      white-space: pre;
+    }
+
     .panel {
       border: 1px solid var(--line);
       border-radius: 6px;
@@ -332,6 +375,7 @@
 
       .metrics,
       .grid,
+      .workflow,
       .figure-grid {
         grid-template-columns: 1fr;
       }
@@ -348,7 +392,8 @@
       <a class="brand" href="#">Swedish Medical Benchmark</a>
       <div class="nav-links">
         <a href="#benchmarks">Benchmarks</a>
-        <a href="#results">Results</a>
+        <a href="#evaluate">Evaluate</a>
+        <a href="#leaderboard">Leaderboard</a>
         <a href="#figures">Figures</a>
         <a href="#grpo">GRPO</a>
         <a href="#contribute">Contribute</a>
@@ -364,6 +409,7 @@
       <p class="byline">Created by Birger Moëll, Fabian Farestam, and Jonas Beskow.</p>
       <div class="actions">
         <a class="button" href="https://github.com/BirgerMoell/swedish-medical-benchmark/">View on GitHub</a>
+        <a class="button secondary" href="#evaluate">Evaluate a model</a>
         <a class="button secondary" href="https://www.frontiersin.org/journals/artificial-intelligence/articles/10.3389/frai.2025.1557920/full">Read the paper</a>
       </div>
     </div>
@@ -379,7 +425,8 @@
         SMLB measures how language models handle Swedish medical terminology,
         clinical reasoning, exam-style questions, emergency scenarios, and
         general medicine cases. It is designed for transparent model comparison,
-        research, and medical education experiments.
+        before/after fine-tuning studies, research, and medical education
+        experiments.
       </p>
       <div class="metrics">
         <div class="metric"><strong>1,000</strong><span>PubMedQA-Swedish questions</span></div>
@@ -411,9 +458,53 @@
       </div>
     </section>
 
-    <section id="results" aria-labelledby="results-title">
-      <h2 id="results-title">Preliminary Model Results</h2>
-      <p class="section-intro">Accuracy is reported as a percentage. A dash means the model has not been evaluated on that benchmark in the current table.</p>
+    <section id="evaluate" aria-labelledby="evaluate-title">
+      <h2 id="evaluate-title">Evaluate a Model</h2>
+      <p class="section-intro">
+        Use SMLB to evaluate a new model, compare two models, or measure a
+        change such as fine-tuning, RAG, quantization, prompting, or decoding
+        settings. Keep the benchmark list, prompt templates, and decoding
+        settings fixed across runs you want to compare.
+      </p>
+      <div class="workflow">
+        <div class="step">
+          <strong>1. Choose fixed tasks</strong>
+          <p>Run every supported benchmark when possible. If you use a subset, report exactly which benchmarks and question counts were included.</p>
+        </div>
+        <div class="step">
+          <strong>2. Save the run</strong>
+          <p>Save the result JSON and evaluation text output. Keep prompts, answer formats, model metadata, and decoding settings with the result.</p>
+        </div>
+        <div class="step">
+          <strong>3. Report clearly</strong>
+          <p>Report per-benchmark metrics, malformed answers, and PubMedQA label behavior. For comparisons, include the per-benchmark delta.</p>
+        </div>
+      </div>
+      <pre class="command-block"><code>python run_llm/huggingface.py \
+  --model-name /path/to/model-or-hf-id \
+  --benchmarks EmergencyMedicine GeneralPractioner SwedishDoctorsExam PubMedQA-L-SWE \
+  --output results/my-model-smlb.json
+
+python evaluate_performance.py \
+  --results results/my-model-smlb.json \
+  --save-result-path results/my-model-smlb-eval.txt</code></pre>
+      <div class="callout">
+        Want to add a model to the leaderboard? Submit the result JSON,
+        evaluation text output, exact model/checkpoint, benchmark list, prompt,
+        decoding settings, SMLB commit, malformed-answer counts, and a
+        contamination statement. See the
+        <a href="https://github.com/BirgerMoell/swedish-medical-benchmark/#evaluate-a-model">full README workflow</a>.
+      </div>
+    </section>
+
+    <section id="leaderboard" aria-labelledby="leaderboard-title">
+      <h2 id="leaderboard-title">Preliminary Leaderboard</h2>
+      <p class="section-intro">
+        Accuracy is reported as a percentage. A dash means the model has not
+        been evaluated on that benchmark in the current table. Because some rows
+        are partial, compare models benchmark by benchmark rather than treating
+        this as a single overall ranking.
+      </p>
       <div class="table-wrap">
         <table>
           <thead>
@@ -431,9 +522,21 @@
             <tr><td>GPT-4</td><td>53.90</td><td>79.07</td><td><strong>93.10</strong></td><td><strong>93.09</strong></td><td><strong>75.57</strong></td></tr>
             <tr><td>Claude-3.5</td><td>-</td><td><strong>83.74</strong></td><td>-</td><td>-</td><td>-</td></tr>
             <tr><td>Llama3-70b</td><td>56.00</td><td>69.91</td><td>74.35</td><td>67.57</td><td>64.88</td></tr>
+            <tr><td>Llama3-8b</td><td>50.50</td><td>41.68</td><td>-</td><td>-</td><td>-</td></tr>
+            <tr><td>Llama3.1-70b</td><td>-</td><td>71.40</td><td>62.93</td><td>71.02</td><td>-</td></tr>
+            <tr><td>Llama3.1-8b</td><td>-</td><td>6.36</td><td>-</td><td>-</td><td>-</td></tr>
             <tr><td>Gemma2-9b</td><td>-</td><td>61.31</td><td>-</td><td>-</td><td>-</td></tr>
+            <tr><td>Gemma-7b</td><td>48.70</td><td>27.48</td><td>-</td><td>-</td><td>-</td></tr>
+            <tr><td>EIR</td><td>46.50</td><td>-</td><td>-</td><td>-</td><td>-</td></tr>
+            <tr><td>GPT-3.5</td><td>27.40</td><td>-</td><td>-</td><td>-</td><td>-</td></tr>
           </tbody>
         </table>
+      </div>
+      <div class="callout" style="margin-top: 18px;">
+        New leaderboard entries should include the result JSON, evaluation text
+        output, model metadata, benchmark coverage, decoding settings, and
+        contamination statement. Partial results are welcome when they are
+        clearly marked.
       </div>
     </section>
 


### PR DESCRIPTION
## Summary

- Generalize the README evaluation workflow so it applies to any new model, comparison, or modified inference setup.
- Add reproducibility guidance for reporting and submitting new benchmark results.
- Add CLI flags for the Hugging Face runner and evaluator so result files can be saved and compared without editing constants.
- Add a public website evaluation section and explicit preliminary leaderboard, synced across `docs/` and `website/`.

## Validation

- `git diff --check`
- Python 3.11 AST parse for `run_llm/huggingface.py` and `evaluate_performance.py`
- HTML parse for `docs/index.html` and `website/index.html`
- Verified `docs/index.html` and `website/index.html` are identical

I did not run a full model evaluation in this local environment because the available Python 3.10+ interpreters do not have the repo dependencies installed.